### PR TITLE
fix for fromNSQ

### DIFF
--- a/st/library/fromNSQ.go
+++ b/st/library/fromNSQ.go
@@ -58,7 +58,7 @@ func (b *FromNSQ) Run() {
 	for {
 		select {
 		case msg := <-toOut:
-			b.out <- &msg
+			b.out <- msg
 		case err := <-toError:
 			b.Error(err)
 		case ruleI := <-b.inrule:


### PR DESCRIPTION
messages that come out of fromNSQ now work with the rest of the blocks in ST. It was sending a pointer when it shouldn't have.

![screen shot 2014-03-08 at 12 50 22 pm](https://f.cloud.github.com/assets/597897/2365979/2cb7e592-a6ea-11e3-92f8-fc415af87084.png)
look! no errors!
