### PR TITLE
fix#313

### DIFF
--- a/st/library/library.go
+++ b/st/library/library.go
@@ -14,7 +14,6 @@ var Blocks = map[string]func() blocks.BlockInterface{
 	"frompost":        NewFromPost,
 	"tonsq":           NewToNSQ,
 	"toelasticsearch": NewToElasticsearch,
-	"towebsocket":     NewToWebsocket,
 	"tofile":          NewToFile,
 	"tolog":           NewToLog,
 	"tobeanstalkd":    NewToBeanstalkd,


### PR DESCRIPTION
apparently towebsocket was in the library twice, probably due to a failed merge.
