### PR TITLE
fix for #297

### DIFF
--- a/st/blocks/blocks.go
+++ b/st/blocks/blocks.go
@@ -203,7 +203,7 @@ func BlockRoutine(bi BlockInterface) {
 
 	for {
 		select {
-		case <- dropTicker.C:
+		case <-dropTicker.C:
 			go func(id string, count int64) {
 				loghub.Log <- &loghub.LogMsg{
 					Type: loghub.ERROR,


### PR DESCRIPTION
Previously, when a block was not able to keep up with a stream, it would log every message it couldn't process and spawn a go routine that would forever attempt to deliver that message. This was bad for a couple of reasons
- one go routine per dropped message
- too many logging statements to the UI
- go routine attempting to deliver to dropped messages would panic if anything downstream was deleted.
  The situation would become increasingly worse, eventually killing the client as well as the server. (discussed in #297)

This change makes it so that when a block is overwhelmed the messages that it is unable to process are dropped forever. When the blocks starts dropping messages, a ticker is started, and until the dropped message count reaches 0, an error message is sent once a second with the sum of dropped messages for that second.

The setup I used to test was (3) 1ms tickers a map with a large dummy msg, and a tonsq on a m1.small: 

```
{"Blocks":[{"Id":"1","Type":"ticker","Rule":{"Interval":"1ms"},"Position":{"X":267,"Y":180}},{"Id":"2","Type":"ticker","Rule":{"Interval":"1ms"},"Position":{"X":355,"Y":177}},{"Id":"3","Type":"ticker","Rule":{"Interval":"1ms"},"Position":{"X":437,"Y":173}},{"Id":"4","Type":"map","Rule":{"Additive":true,"Map":{"test":"'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce sodales fermentum leo, pulvinar scelerisque odio semper fermentum. Vestibulum at dui sit amet felis egestas vulputate. Vivamus porta dignissim lacinia. Nunc hendrerit ultricies sagittis. Maecenas laoreet eleifend eleifend. Phasellus cursus id purus ut feugiat. Vivamus a dictum nunc, ac scelerisque dolor. Cras nec ligula laoreet, sodales dui ut, imperdiet lorem. Maecenas non condimentum dui. Donec euismod est dignissim nunc commodo viverra. Nam bibendum metus ipsum, in laoreet massa rutrum eget. Nullam a facilisis nibh. Sed accumsan sagittis ligula vitae tempus. Proin condimentum ligula sit amet hendrerit vestibulum. Nam fringilla venenatis sapien eget lobortis. Aliquam erat volutpat.Vivamus hendrerit ante nec lorem feugiat dignissim. Vivamus venenatis egestas diam sit amet pretium. Aliquam ultrices volutpat erat nec tristique. Etiam tempus feugiat diam, sit amet aliquam nisl suscipit nec. Nam vel lacinia dolor. Maecenas bibendum lectus et diam rutrum eleifend. Nulla laoreet at odio sed rhoncus.Quisque laoreet, enim ut luctus tempor, elit purus ultrices nulla, in dictum metus est imperdiet risus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Vestibulum pellentesque lorem ante, at molestie arcu ornare quis. Nunc sed dapibus nulla. Sed posuere commodo lectus, ut lobortis diam laoreet non. Etiam tincidunt est non tortor pharetra, a auctor elit cursus. Donec enim turpis, tempus vitae nulla sit amet, fermentum sagittis dolor. Nulla in dictum ipsum. Donec quam purus, venenatis eget ornare eu, elementum quis felis. Phasellus a volutpat velit. Praesent leo odio, mattis id egestas sit amet, fringilla ac leo. Fusce ac erat et lacus egestas faucibus. Pellentesque accumsan lobortis enim id accumsan. Morbi non varius libero, id scelerisque sapien.Duis at quam quis purus vehicula ullamcorper quis id metus. Phasellus pharetra eros in fringilla tincidunt. In ac faucibus arcu, eu sollicitudin ante. Vivamus quam augue, pellentesque ut sapien vitae, rhoncus tincidunt massa. Nulla a risus arcu. Aliquam et blandit nibh, vel viverra mi. Morbi elit erat, rhoncus quis vestibulum a, convallis viverra lectus. Nam convallis pulvinar nisi, eu aliquam est ultricies sed. Pellentesque venenatis lectus at tortor dapibus tristique. Etiam sit amet euismod turpis.Nullam tempus ipsum id venenatis tempus. Phasellus vitae sollicitudin ligula, quis feugiat magna. Nam id nisi fringilla augue pellentesque porttitor sit amet ac magna. Etiam semper imperdiet mauris vitae gravida. Aliquam tristique molestie elit, vel elementum lacus vehicula ut. Proin libero justo, ullamcorper et tristique non, tempus in ante. Vivamus tempus, magna in rhoncus sagittis, neque tortor interdum est, et semper libero ante quis ante. Vestibulum a nulla neque. Phasellus quis ligula pretium, dapibus lorem id, luctus mi. Nullam leo diam, convallis ut consectetur sodales, mattis vel ipsum. Donec at purus sit amet ante laoreet elementum. Morbi vitae magna ac tortor interdum semper et ac nunc. Mauris et aliquam sapien, vitae luctus sem.Sed sed viverra turpis, a mattis erat. Maecenas accumsan pretium sapien non dictum. Sed venenatis nulla in ligula vulputate, ac vehicula sem tincidunt. Integer iaculis felis ac nunc imperdiet scelerisque. In quis eros dui. In posuere ipsum est, id tincidunt nibh fringilla quis. Proin dapibus vitae risus et aliquet. Donec cursus lorem libero, id imperdiet ante sodales at. Integer in mi dapibus, auctor lorem id, fringilla arcu. Sed mollis adipiscing nibh sed tempus.Ut interdum suscipit sagittis. Morbi commodo euismod luctus. Curabitur eget tincidunt ipsum. Donec non lectus dictum ligula suscipit blandit. Duis dictum mi non orci lacinia semper. Aenean erat elit, lobortis sit amet erat in, consectetur condimentum augue. Curabitur sagittis lacinia sapien, quis tincidunt quam convallis eget. Aenean aliquam nibh ac est cursus, at pretium sapien rhoncus. Sed ultrices arcu mauris, vel porttitor justo pharetra a. Phasellus mattis enim augue, in venenatis nisi tempor eget. Morbi nibh nisl, eleifend vel enim et, convallis bibendum felis. Vestibulum eget lobortis erat. Curabitur pharetra molestie elit, non blandit nunc sodales id. Integer fringilla massa venenatis risus condimentum lobortis. Praesent vel orci nulla. Donec quam nibh, aliquet vel diam convallis, vehicula pharetra nunc.Ut sed nulla ultrices, tempus felis eu, vulputate lectus. Nulla consectetur porttitor velit in tincidunt. Cras at ipsum porttitor, aliquet enim in, ultrices mi. Vivamus adipiscing leo nec tellus lacinia, id malesuada sapien luctus. Curabitur ac pharetra orci, vitae fringilla est. Vivamus id mattis eros, sed convallis mauris. Mauris lacinia tempor rhoncus.Nulla cursus, massa nec iaculis consequat, purus lectus tempor odio, sed semper nisi justo a metus. Donec elementum bibendum dignissim. Ut sed tristique purus. Sed sagittis quis lectus at lacinia. Aenean ultricies nisl vel nisl sollicitudin porta. Suspendisse dictum enim id neque tincidunt gravida. Nam in suscipit metus.Duis sodales euismod magna, quis dapibus leo rhoncus sit amet. Vivamus vulputate lectus nec tortor luctus, aliquet faucibus turpis gravida. Nam elementum feugiat libero, eget mattis lorem suscipit vel. Cras sed hendrerit tortor. Quisque ultrices nisi vehicula sem venenatis, quis fermentum ligula tincidunt. Nam facilisis sollicitudin molestie. Duis sit amet ornare elit. Sed eu pretium erat, quis pretium urna. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam vestibulum lobortis dolor in imperdiet. Curabitur suscipit lacus at neque porta vulputate eu vitae libero. Phasellus dolor sapien, aliquam quis dolor nec, gravida adipiscing lectus.'"}},"Position":{"X":462,"Y":324}},{"Id":"5","Type":"tonsq","Rule":{"NsqdTCPAddrs":"localhost:4150","Topic":"test"},"Position":{"X":548,"Y":445}}],"Connections":[{"Id":"6","FromId":"1","ToId":"4","ToRoute":"in"},{"Id":"7","FromId":"2","ToId":"4","ToRoute":"in"},{"Id":"8","FromId":"3","ToId":"4","ToRoute":"in"},{"Id":"9","FromId":"4","ToId":"5","ToRoute":"in"}]}
```

![screen shot 2014-03-26 at 11 56 02 am](https://f.cloud.github.com/assets/597897/2526947/2eec3f0c-b4ff-11e3-95e6-dceec4bbb736.png)
