### PR TITLE
fromSQS url constructing + test endpoint xml response, fixes #347

### DIFF
--- a/st/library/library_test.go
+++ b/st/library/library_test.go
@@ -232,7 +232,23 @@ func (s *StreamSuite) TestToFile(c *C) {
 func (s *StreamSuite) TestFromSQS(c *C) {
 	log.Println("testing FromSQS")
 
+	sampleResponse := string(`
+<CreateQueueResponse
+  xmlns="http://sqs.us-east-1.amazonaws.com/doc/2012-11-05/"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:type="CreateQueueResponse">
+     <CreateQueueResult>
+        <QueueUrl>
+        http://sqs.us-east-1.amazonaws.com/770098461991/queue2
+        </QueueUrl>
+     </CreateQueueResult>
+     <ResponseMetadata>
+        <RequestId>cb919c0a-9bce-4afe-9b48-9bdf2412bb67</RequestId>
+     </ResponseMetadata>
+</CreateQueueResponse>
+  `)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, sampleResponse)
 	}))
 	defer ts.Close()
 


### PR DESCRIPTION
This fixes the build by using the net/url pkg to construct the url with query string. It also makes the test respond with sample xml pulled directly from the aws docs at http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/UnderstandingResponses.html#ResponseStructure
