### PR TITLE
Added a command line version flag to st binary

### DIFF
--- a/st/main.go
+++ b/st/main.go
@@ -2,20 +2,29 @@ package main
 
 import (
 	"flag"
-	"github.com/nytlabs/streamtools/st/server"
 	"github.com/nytlabs/streamtools/st/library"
 	"github.com/nytlabs/streamtools/st/loghub"
+	"github.com/nytlabs/streamtools/st/server"
+	"github.com/nytlabs/streamtools/st/util"
 	"log"
+	"os"
 )
 
 var (
 	// port that streamtools reuns on
-	port   = flag.String("port", "7070", "streamtools port")
-	domain = flag.String("domain", "127.0.0.1", "streamtools domain")
+	port    = flag.String("port", "7070", "streamtools port")
+	domain  = flag.String("domain", "127.0.0.1", "streamtools domain")
+	version = flag.Bool("version", false, "prints current streamtools version")
 )
 
 func main() {
 	flag.Parse()
+
+	if *version {
+		log.Println("Streamtools version:", util.VERSION)
+		os.Exit(0)
+	}
+
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 
 	library.Start()


### PR DESCRIPTION
$ st -version
2014/04/03 15:40:56 Streamtools version: 0.2.3

This can be used to verify streamtools installs correctly (e.g. in homebrew formula, docker, etc)
