### PR TITLE
replace contents of ref pane with block list instead of prepending

### DIFF
--- a/gui/static/js/main.js
+++ b/gui/static/js/main.js
@@ -568,7 +568,7 @@ $(function() {
             var refTmpl = _.template(refTemplate, {
               data: blocks
             });
-            $("#ui-ref-contents").prepend(refTmpl);
+            $("#ui-ref-contents").html(refTmpl);
         };
         this.ws.onclose = uiReconnect;
         this.ws.onmessage = function(d) {


### PR DESCRIPTION
no need to prepend the contents as this reference pane only has the list of blocks. fixes #411
