### PR TITLE
cleanup of api route handlers

### DIFF
--- a/st/server/api.go
+++ b/st/server/api.go
@@ -65,7 +65,7 @@ func (s *Server) exampleHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	w.Header().Set("Content-Type", resourceType[vars["type"]])
 	data, _ := Asset("examples/" + vars["file"])
-	w.Write(data)
+	s.apiWrap(w, r, 200, data)
 }
 
 func (s *Server) staticHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
I removed the tutorial handlers as they're going into gh-pages. The handler for /examples now uses the same apiWrap func to include CORS related headers allowing cross-domain loading of patterns.
