### PR TITLE
Added retry logic for ToEmail's send and reconnect

### DIFF
--- a/st/library/toEmail.go
+++ b/st/library/toEmail.go
@@ -325,6 +325,7 @@ func (e *ToEmail) Run() {
 				// attempt to reset client after each failure.
 				connected = e.resetClient()
 				if !connected {
+					// if we cannot reconnect, dont retry sending.
 					break
 				}
 				time.Sleep(time.Duration(retries*errWait) * time.Second)
@@ -334,8 +335,7 @@ func (e *ToEmail) Run() {
 			}
 
 			// reset the connection and the counter every 50 msgs or if theres been a send error.
-			// why 50?
-			if sent >= 50 || (err != nil && !connected) {
+			if (sent >= 50) || (err != nil) {
 				sent = 0
 				e.resetClient()
 			}


### PR DESCRIPTION
If the ToEmail block encounters an error while sending or connecting, it will now attempt 5 retries at the operation with an incremental back off of 10s before giving up and carrying on. 

Let me know if we want the # of retries and attempts to be configurable and I can toss them in the inrule.
