### PR TITLE
Fixes #471 introText js var out of scope

### DIFF
--- a/gui/static/js/main.js
+++ b/gui/static/js/main.js
@@ -332,7 +332,7 @@ $(function() {
             .attr('height', window.innerHeight);
         bg.attr('width', window.innerWidth)
             .attr('height', window.innerHeight);
-        introText.attr('x', window.innerWidth/2)
+        d3.select('intro-text').attr('x', window.innerWidth/2)
             .attr('y', window.innerHeight/2);
     });
 


### PR DESCRIPTION
using d3 to select the element to get around the scope funkiness.
