### PR TITLE
From file fix

### DIFF
--- a/st/library/fromFile.go
+++ b/st/library/fromFile.go
@@ -86,7 +86,7 @@ func (b *FromFile) Run() {
 			// if the json parsing fails, store data unparsed as "data"
 			if err != nil {
 				outMsg = map[string]interface{}{
-					"data": line,
+					"data": string(line),
 				}
 			}
 


### PR DESCRIPTION
in the circumstance that one is reading from a non-JSON file, the line would be emitted as bytes and not as a string. this fixes that.
