### PR TITLE
webRequest block fixes

### DIFF
--- a/st/library/webRequest.go
+++ b/st/library/webRequest.go
@@ -139,11 +139,23 @@ func (b *WebRequest) Run() {
 				break
 			}
 
-			b.out <- map[string]interface{}{
-				"Response": string(body),
+			var responseBody interface{}
+			err = json.Unmarshal(body, &responseBody)
+			if err != nil {
+				responseBody = string(body)
+			}
+
+			// always return body/headers/status even if it's nasty xml
+			outMsg := map[string]interface{}{
+				"body":    responseBody,
+				"headers": resp.Header,
+				"status":  resp.Status,
 			}
 
 			resp.Body.Close()
+
+			b.out <- outMsg
+
 		case resp := <-b.queryrule:
 			resp <- map[string]interface{}{
 				"Url":     url,

--- a/tests/webRequest_test.go
+++ b/tests/webRequest_test.go
@@ -38,6 +38,7 @@ func (s *WebRequestSuite) TestWebRequestPost(c *C) {
 	}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		fmt.Fprint(w, okResponse)
 	}))
 
@@ -77,7 +78,11 @@ func (s *WebRequestSuite) TestWebRequestPost(c *C) {
 			}
 		case messageI := <-outChan:
 			message := messageI.Msg.(map[string]interface{})
-			c.Assert(message["Response"], NotNil)
+			messageHeaders := message["headers"].(http.Header)
+			c.Assert(message["body"], NotNil)
+			c.Assert(message["headers"], NotNil)
+			c.Assert(messageHeaders.Get("Content-Type"), Equals, "application/json; charset=utf-8")
+			c.Assert(message["status"], Equals, "200 OK")
 		}
 	}
 }
@@ -100,6 +105,7 @@ func (s *WebRequestSuite) TestWebRequestGet(c *C) {
 		c.Fail()
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		fmt.Fprint(w, okResponse)
 	}))
 
@@ -137,8 +143,80 @@ func (s *WebRequestSuite) TestWebRequestGet(c *C) {
 				log.Println("Rule mismatch:", messageI, ruleMsg)
 				c.Fail()
 			}
-		case msg := <-outChan:
-			log.Println(msg)
+		case messageI := <-outChan:
+			message := messageI.Msg.(map[string]interface{})
+			messageHeaders := message["headers"].(http.Header)
+			c.Assert(message["body"], NotNil)
+			c.Assert(message["headers"], NotNil)
+			c.Assert(messageHeaders.Get("Content-Type"), Equals, "application/json; charset=utf-8")
+			c.Assert(message["status"], Equals, "200 OK")
+		}
+	}
+}
+
+func (s *WebRequestSuite) TestWebRequestGetXML(c *C) {
+	log.Println("testing WebRequest: GET with XML")
+	b, ch := test_utils.NewBlock("testingWebRequestGetXML", "webRequest")
+	go blocks.BlockRoutine(b)
+	outChan := make(chan *blocks.Msg)
+	ch.AddChan <- &blocks.AddChanMsg{
+		Route:   "out",
+		Channel: outChan,
+	}
+
+	var xmldata = string(`
+  <?xml version="1.0" encoding="utf-8"?>
+  <OdfBody DocumentType="DT_GM" Date="20130131" Time="140807885" LogicalDate="20130131" Venue="ACV" Language="ENG" FeedFlag="P" DocumentCode="AS0ACV000" Version="3" Serial="1">
+    <Competition Code="OG2014">
+      <Config SDelay="60" />
+    </Competition>
+  </OdfBody>
+  `)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, xmldata)
+	}))
+
+	defer ts.Close()
+
+	headers := map[string]interface{}{"Content-Type": "application/xml"}
+	ruleMsg := map[string]interface{}{"Url": ts.URL, "Method": "GET", "Headers": headers}
+	toRule := &blocks.Msg{Msg: ruleMsg, Route: "rule"}
+	ch.InChan <- toRule
+
+	queryOutChan := make(blocks.MsgChan)
+	time.AfterFunc(time.Duration(1)*time.Second, func() {
+		ch.QueryChan <- &blocks.QueryMsg{MsgChan: queryOutChan, Route: "rule"}
+	})
+
+	time.AfterFunc(time.Duration(2)*time.Second, func() {
+		emptyMsg := make(map[string]interface{})
+		postData := &blocks.Msg{Msg: emptyMsg, Route: "in"}
+		ch.InChan <- postData
+	})
+
+	time.AfterFunc(time.Duration(5)*time.Second, func() {
+		ch.QuitChan <- true
+	})
+	for {
+		select {
+		case err := <-ch.ErrChan:
+			if err != nil {
+				c.Errorf(err.Error())
+			} else {
+				return
+			}
+		case messageI := <-queryOutChan:
+			if !reflect.DeepEqual(messageI, ruleMsg) {
+				log.Println("Rule mismatch:", messageI, ruleMsg)
+				c.Fail()
+			}
+		case messageI := <-outChan:
+			message := messageI.Msg.(map[string]interface{})
+			messageHeaders := message["headers"].(http.Header)
+			c.Assert(message["body"], NotNil)
+			c.Assert(message["headers"], NotNil)
+			c.Assert(messageHeaders.Get("Content-Type"), Equals, "text/xml; charset=utf-8")
+			c.Assert(message["status"], Equals, "200 OK")
 		}
 	}
 }


### PR DESCRIPTION
outgoing messages from this block now include better response data:

body: if json, it's unmarshalled, other formats are strings (xml, csv) that can be later parsed.
headers: any headers returned, like Content-Type etc.
status: ideally a 200 OK ;)

I updated the tests, which now include POST and GET requests with JSON and XML incoming data.

this closes #488 
