### PR TITLE
tidied up websocket a little

### DIFF
--- a/st/server/api.go
+++ b/st/server/api.go
@@ -247,7 +247,7 @@ func (s *Server) websocketHandler(w http.ResponseWriter, r *http.Request) {
 				default:
 					loghub.Log <- &loghub.LogMsg{
 						Type: loghub.ERROR,
-						Data: "websocket send is blocked!",
+						Data: "websocket send is blocked! Exiting.",
 						Id:   s.Id,
 					}
 					return


### PR DESCRIPTION
so now the write to the websocket in the api's websocket handler uses the connection's writePump. If the send to the write pump fails for whatever reason, we treat that websocket as dead and the handler returns noisily. With any luck should solve all sad websocket problems. Hopefully fixes #486 
