### PR TITLE
moved queue to the core group and renamed Queues to Queue I/O

### DIFF
--- a/st/library/fromAMQP.go
+++ b/st/library/fromAMQP.go
@@ -23,7 +23,7 @@ func NewFromAMQP() blocks.BlockInterface {
 }
 
 func (b *FromAMQP) Setup() {
-	b.Kind = "Queues"
+	b.Kind = "Queue I/O"
 	b.Desc = "reads from a topic on AMQP broker as specified in this block's rules"
 	b.inrule = b.InRoute("rule")
 	b.queryrule = b.QueryRoute("rule")

--- a/st/library/fromNSQ.go
+++ b/st/library/fromNSQ.go
@@ -25,7 +25,7 @@ func NewFromNSQ() blocks.BlockInterface {
 }
 
 func (b *FromNSQ) Setup() {
-	b.Kind = "Queues"
+	b.Kind = "Queue I/O"
 	b.Desc = "reads from a topic in NSQ as specified in this block's rule"
 	b.inrule = b.InRoute("rule")
 	b.queryrule = b.QueryRoute("rule")

--- a/st/library/fromSQS.go
+++ b/st/library/fromSQS.go
@@ -183,7 +183,7 @@ func NewFromSQS() blocks.BlockInterface {
 
 // Setup is called once before running the block. We build up the channels and specify what kind of block this is.
 func (b *FromSQS) Setup() {
-	b.Kind = "Queues"
+	b.Kind = "Queue I/O"
 	b.Desc = "reads from Amazon's SQS, emitting each line of JSON as a separate message"
 	b.inrule = b.InRoute("rule")
 	b.queryrule = b.QueryRoute("rule")

--- a/st/library/queue.go
+++ b/st/library/queue.go
@@ -25,7 +25,7 @@ func NewQueue() blocks.BlockInterface {
 
 // Setup is called once before running the block. We build up the channels and specify what kind of block this is.
 func (b *Queue) Setup() {
-	b.Kind = "Queues"
+	b.Kind = "Core"
 	b.Desc = "FIFO queue allowing push & pop on streams plus popping from a query"
 	b.inPush = b.InRoute("push")
 	b.inPop = b.InRoute("pop")

--- a/st/library/toAMQP.go
+++ b/st/library/toAMQP.go
@@ -23,7 +23,7 @@ func NewToAMQP() blocks.BlockInterface {
 }
 
 func (b *ToAMQP) Setup() {
-	b.Kind = "Queues"
+	b.Kind = "Queue I/O"
 	b.Desc = "send messages to an exchange on an AMQP broker"
 	b.in = b.InRoute("in")
 	b.inrule = b.InRoute("rule")

--- a/st/library/toBeanstalkd.go
+++ b/st/library/toBeanstalkd.go
@@ -25,7 +25,7 @@ func NewToBeanstalkd() blocks.BlockInterface {
 
 // Setup is called once before running the block. We build up the channels and specify what kind of block this is.
 func (b *ToBeanstalkd) Setup() {
-	b.Kind = "Queues"
+	b.Kind = "Queue I/O"
 	b.Desc = "sends jobs to beanstalkd tube"
 	b.in = b.InRoute("in")
 	b.inrule = b.InRoute("rule")

--- a/st/library/toNSQ.go
+++ b/st/library/toNSQ.go
@@ -24,7 +24,7 @@ func NewToNSQ() blocks.BlockInterface {
 }
 
 func (b *ToNSQ) Setup() {
-	b.Kind = "Queues"
+	b.Kind = "Queue I/O"
 	b.Desc = "send messages to an NSQ topic"
 	b.in = b.InRoute("in")
 	b.inrule = b.InRoute("rule")

--- a/st/library/toNSQMulti.go
+++ b/st/library/toNSQMulti.go
@@ -25,7 +25,7 @@ func NewToNSQMulti() blocks.BlockInterface {
 }
 
 func (b *ToNSQMulti) Setup() {
-	b.Kind = "Queues"
+	b.Kind = "Queue I/O"
 	b.Desc = "sends messages to an NSQ topic in batches"
 	b.in = b.InRoute("in")
 	b.inrule = b.InRoute("rule")


### PR DESCRIPTION
this hopefully resolves, a little late, a question from @mboggie in #502 about the categorisation of the queue block and the Queues block section by moving queue back to "Core" and changing the "Queues" section to "Queue I/O".
