### PR TITLE
webRequest block no longer confuses specified url vs url from path

### DIFF
--- a/st/library/webRequest.go
+++ b/st/library/webRequest.go
@@ -60,6 +60,7 @@ func (b *WebRequest) Run() {
 	var ok bool
 
 	url := ""
+	requestUrl := ""
 	var urlPath string
 	var urlTree *jee.TokenTree
 
@@ -110,6 +111,10 @@ func (b *WebRequest) Run() {
 			if len(url) != 0 && len(urlPath) != 0 {
 				b.Error(errors.New("Specify either a url or a path to a url"))
 				continue
+			}
+
+			if len(urlPath) == 0 {
+				urlTree = nil
 			}
 
 			if len(url) == 0 {
@@ -167,11 +172,17 @@ func (b *WebRequest) Run() {
 					b.Error(err)
 					continue
 				}
-				url, ok = urlInterface.(string)
+				// use the url found via rule.UrlPath in the request
+				requestUrl, ok = urlInterface.(string)
 				if !ok {
 					b.Error(errors.New("couldn't assert url to a string"))
 					continue
 				}
+			}
+
+			// use the rule.Url in the request
+			if len(url) != 0 {
+				requestUrl = url
 			}
 
 			if httpMethod == "POST" || httpMethod == "PUT" {
@@ -186,14 +197,14 @@ func (b *WebRequest) Run() {
 					continue
 				}
 
-				req, err = http.NewRequest(httpMethod, url, bytes.NewReader(requestBody))
+				req, err = http.NewRequest(httpMethod, requestUrl, bytes.NewReader(requestBody))
 				if err != nil {
 					b.Error(err)
 					break
 				}
 
 			} else {
-				req, err = http.NewRequest(httpMethod, url, nil)
+				req, err = http.NewRequest(httpMethod, requestUrl, nil)
 				if err != nil {
 					b.Error(err)
 					break


### PR DESCRIPTION
Fixes #535 - when specifying a UrlPath, the variable 'url' was being set to the string found in an incoming message at that path. This caused a couple problems:
1. the rule window in the streamtools UI would show values in both UrlPath and Url 
2. streamtools would error: "Specify either a url or a path to a url"
3. subsequent messages with new urls would just trigger a request to the first url.

Ack. This fixes all of those problems. I tested a few different scenarios:
1. Url set -> change to UrlPath -> change back to Url
2. UrlPath set -> change to Url -> back to UrlPath
3. UrlPath set -> send different urls in json -> change to Url

etc. 
