### PR TITLE
Sqs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,3 +3,5 @@ WORKDIR /gopath/src/github.com/nytlabs/streamtools
 ADD . /gopath/src/github.com/nytlabs/streamtools
 RUN make clean
 RUN make
+RUN ["mkdir", "-p", "/gopath/bin"]
+RUN ["ln", "-s", "/gopath/src/github.com/nytlabs/streamtools/build/st", "/gopath/bin/st"]


### PR DESCRIPTION
quick hacks to fix the from SQS block. Needs work in the future - maybe waitgroups and a fixed number (> 1) of readers would be nice instead of this clumsy locking an unlocking. Also adds a 1second wait time to block the reader for a second at a time if there are no messages on the queue. This means max additional latency for slow streams on SQS will be 1 sec.
