### PR TITLE
fixed toEmail tls

### DIFF
--- a/st/library/toEmail.go
+++ b/st/library/toEmail.go
@@ -1,6 +1,7 @@
 package library
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net/smtp"
@@ -111,7 +112,8 @@ func newSMTPClient(username, password, host string, port int) (*smtp.Client, err
 
 	// if the server can handle TLS, use it
 	if ok, _ := client.Extension("STARTTLS"); ok {
-		if err = client.StartTLS(nil); err != nil {
+		cfg := &tls.Config{ServerName: host}
+		if err = client.StartTLS(cfg); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
fixing the "tls: either ServerName or InsecureSkipVerify must be specified in the tls.Config" error in toEmail block
